### PR TITLE
Update index.js to fix widget comment section paddings

### DIFF
--- a/src/widget/index.js
+++ b/src/widget/index.js
@@ -54,7 +54,7 @@ const generateModalStyles = () => {
     margin-bottom: 1rem;
     border: 1px solid #ccc;
     flex-shrink: 0;
-    padding-right: 8px;
+    padding: 5px;
   }
 
   #hexlet-correction-modal_ReportTypo-name {


### PR DESCRIPTION
Привёл паддинги двух полей в виджете к единообразию

Before:
![before](https://github.com/bazilval/hexlet-correction/assets/29205112/26aed7f3-ff95-44c0-a836-4a6c237a640e)

After:
![after](https://github.com/bazilval/hexlet-correction/assets/29205112/4bee428d-c077-4e0c-9ae7-636fb96ad4c9)
